### PR TITLE
채팅 도메인 기능 마무리

### DIFF
--- a/waggle-api/src/main/java/com/trip/api/chatting/controller/ChattingController.java
+++ b/waggle-api/src/main/java/com/trip/api/chatting/controller/ChattingController.java
@@ -4,6 +4,7 @@ import com.trip.api.chatting.dto.param.DeleteMessageParameter;
 import com.trip.api.chatting.dto.param.SendMessageParameter;
 import com.trip.api.chatting.dto.request.CreateChatMessageRequest;
 import com.trip.api.chatting.dto.request.CreateChatRoomRequest;
+import com.trip.api.chatting.dto.response.GetChatMessageResponse;
 import com.trip.api.chatting.dto.response.GetMyChatRoomResponse;
 import com.trip.api.chatting.service.ChattingService;
 
@@ -71,5 +72,11 @@ public class ChattingController {
     public ResponseEntity<Void> deleteMessage(@PathVariable Long chatRoomId, @PathVariable Long messageId) {
         chattingService.deleteMessage(new DeleteMessageParameter(chatRoomId, messageId, 71L));
         return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("/{chatRoomId}")
+    public ResponseEntity<List<GetChatMessageResponse>> getDetailChatRoom(@PathVariable Long chatRoomId) {
+        List<GetChatMessageResponse> result = chattingService.getChatMessages(chatRoomId);
+        return ResponseEntity.ok(result);
     }
 }

--- a/waggle-api/src/main/java/com/trip/api/chatting/controller/ChattingController.java
+++ b/waggle-api/src/main/java/com/trip/api/chatting/controller/ChattingController.java
@@ -4,6 +4,7 @@ import com.trip.api.chatting.dto.param.DeleteMessageParameter;
 import com.trip.api.chatting.dto.param.SendMessageParameter;
 import com.trip.api.chatting.dto.request.CreateChatMessageRequest;
 import com.trip.api.chatting.dto.request.CreateChatRoomRequest;
+import com.trip.api.chatting.dto.response.GetAllChatRoomMemberResponse;
 import com.trip.api.chatting.dto.response.GetAllChatRoomResponse;
 import com.trip.api.chatting.dto.response.GetChatMessageResponse;
 import com.trip.api.chatting.dto.response.GetMyChatRoomResponse;
@@ -84,6 +85,12 @@ public class ChattingController {
     @GetMapping
     public ResponseEntity<List<GetAllChatRoomResponse>> getAllChatRoom() {
         List<GetAllChatRoomResponse> result = chattingService.getAllChatRoom();
+        return ResponseEntity.ok(result);
+    }
+
+    @GetMapping("/{chatRoomId}/members")
+    public ResponseEntity<GetAllChatRoomMemberResponse> getAllChatRoomMember(@PathVariable Long chatRoomId) {
+        GetAllChatRoomMemberResponse result = chattingService.getAllChatRoomMember(chatRoomId);
         return ResponseEntity.ok(result);
     }
 }

--- a/waggle-api/src/main/java/com/trip/api/chatting/controller/ChattingController.java
+++ b/waggle-api/src/main/java/com/trip/api/chatting/controller/ChattingController.java
@@ -4,6 +4,7 @@ import com.trip.api.chatting.dto.param.DeleteMessageParameter;
 import com.trip.api.chatting.dto.param.SendMessageParameter;
 import com.trip.api.chatting.dto.request.CreateChatMessageRequest;
 import com.trip.api.chatting.dto.request.CreateChatRoomRequest;
+import com.trip.api.chatting.dto.response.GetAllChatRoomResponse;
 import com.trip.api.chatting.dto.response.GetChatMessageResponse;
 import com.trip.api.chatting.dto.response.GetMyChatRoomResponse;
 import com.trip.api.chatting.service.ChattingService;
@@ -46,10 +47,10 @@ public class ChattingController {
         return ResponseEntity.ok().build();
     }
 
-    @GetMapping
+    @GetMapping("/my")
     public ResponseEntity<List<GetMyChatRoomResponse>> getMyChatRooms() {
         List<GetMyChatRoomResponse> result = chattingService.getMyChatRooms(71L);
-        return ResponseEntity.ok().body(result);
+        return ResponseEntity.ok(result);
     }
 
     @PostMapping("/{chatRoomId}")
@@ -77,6 +78,12 @@ public class ChattingController {
     @GetMapping("/{chatRoomId}")
     public ResponseEntity<List<GetChatMessageResponse>> getDetailChatRoom(@PathVariable Long chatRoomId) {
         List<GetChatMessageResponse> result = chattingService.getChatMessages(chatRoomId);
+        return ResponseEntity.ok(result);
+    }
+
+    @GetMapping
+    public ResponseEntity<List<GetAllChatRoomResponse>> getAllChatRoom() {
+        List<GetAllChatRoomResponse> result = chattingService.getAllChatRoom();
         return ResponseEntity.ok(result);
     }
 }

--- a/waggle-api/src/main/java/com/trip/api/chatting/dto/param/ConvertChatMessageParameter.java
+++ b/waggle-api/src/main/java/com/trip/api/chatting/dto/param/ConvertChatMessageParameter.java
@@ -1,6 +1,7 @@
 package com.trip.api.chatting.dto.param;
 
 import com.trip.api.chatting.dto.request.CreateChatMessageRequest;
+
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 

--- a/waggle-api/src/main/java/com/trip/api/chatting/dto/param/SendMessageParameter.java
+++ b/waggle-api/src/main/java/com/trip/api/chatting/dto/param/SendMessageParameter.java
@@ -1,6 +1,7 @@
 package com.trip.api.chatting.dto.param;
 
 import com.trip.api.chatting.dto.request.CreateChatMessageRequest;
+
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 

--- a/waggle-api/src/main/java/com/trip/api/chatting/dto/request/CreateChatMessageRequest.java
+++ b/waggle-api/src/main/java/com/trip/api/chatting/dto/request/CreateChatMessageRequest.java
@@ -9,9 +9,9 @@ import javax.validation.constraints.NotBlank;
 @Getter
 public class CreateChatMessageRequest {
 
-    @NotBlank
+    @NotBlank(message = "빈 메세지를 보낼 수 없습니다.")
     private String message;
 
-    @ValidateType(enumClass = MessageType.class)
+    @ValidateType(enumClass = MessageType.class, message = "올바른 메세지 타입이 아닙니다.")
     private String messageType;
 }

--- a/waggle-api/src/main/java/com/trip/api/chatting/dto/request/CreateChatMessageRequest.java
+++ b/waggle-api/src/main/java/com/trip/api/chatting/dto/request/CreateChatMessageRequest.java
@@ -2,6 +2,7 @@ package com.trip.api.chatting.dto.request;
 
 import com.trip.common.annotation.ValidateType;
 import com.trip.common.type.MessageType;
+
 import lombok.Getter;
 
 import javax.validation.constraints.NotBlank;

--- a/waggle-api/src/main/java/com/trip/api/chatting/dto/request/CreateChatRoomRequest.java
+++ b/waggle-api/src/main/java/com/trip/api/chatting/dto/request/CreateChatRoomRequest.java
@@ -2,7 +2,6 @@ package com.trip.api.chatting.dto.request;
 
 import lombok.Getter;
 
-import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
 
 import java.util.ArrayList;
@@ -10,10 +9,9 @@ import java.util.ArrayList;
 @Getter
 public class CreateChatRoomRequest {
 
-    @NotEmpty
     private ArrayList<Long> joinUsers;
 
-    @NotNull
+    @NotNull(message = "방장은 필수 값입니다.")
     private Long chatRoomMaker;
 
     private String chatRoomName;

--- a/waggle-api/src/main/java/com/trip/api/chatting/dto/response/GetAllChatMember.java
+++ b/waggle-api/src/main/java/com/trip/api/chatting/dto/response/GetAllChatMember.java
@@ -1,0 +1,11 @@
+package com.trip.api.chatting.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class GetAllChatMember {
+
+    private Long memberId;
+}

--- a/waggle-api/src/main/java/com/trip/api/chatting/dto/response/GetAllChatRoomMemberResponse.java
+++ b/waggle-api/src/main/java/com/trip/api/chatting/dto/response/GetAllChatRoomMemberResponse.java
@@ -1,0 +1,14 @@
+package com.trip.api.chatting.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class GetAllChatRoomMemberResponse {
+
+    private Long creator;
+    private List<GetAllChatMember> members;
+}

--- a/waggle-api/src/main/java/com/trip/api/chatting/dto/response/GetAllChatRoomResponse.java
+++ b/waggle-api/src/main/java/com/trip/api/chatting/dto/response/GetAllChatRoomResponse.java
@@ -1,0 +1,12 @@
+package com.trip.api.chatting.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class GetAllChatRoomResponse {
+
+    private Long chatRoomId;
+    private String title;
+}

--- a/waggle-api/src/main/java/com/trip/api/chatting/dto/response/GetChatMessageResponse.java
+++ b/waggle-api/src/main/java/com/trip/api/chatting/dto/response/GetChatMessageResponse.java
@@ -1,6 +1,5 @@
 package com.trip.api.chatting.dto.response;
 
-import com.trip.common.type.MessageType;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 

--- a/waggle-api/src/main/java/com/trip/api/chatting/dto/response/GetChatMessageResponse.java
+++ b/waggle-api/src/main/java/com/trip/api/chatting/dto/response/GetChatMessageResponse.java
@@ -1,0 +1,15 @@
+package com.trip.api.chatting.dto.response;
+
+import com.trip.common.type.MessageType;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class GetChatMessageResponse {
+
+    private Long messageId;
+    private Long memberId;
+    private String message;
+    private String messageType;
+}

--- a/waggle-api/src/main/java/com/trip/api/chatting/dto/response/GetChatRoomCreator.java
+++ b/waggle-api/src/main/java/com/trip/api/chatting/dto/response/GetChatRoomCreator.java
@@ -1,0 +1,11 @@
+package com.trip.api.chatting.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class GetChatRoomCreator {
+
+    Long memberId;
+}

--- a/waggle-api/src/main/java/com/trip/api/chatting/entity/ChatRoomMember.java
+++ b/waggle-api/src/main/java/com/trip/api/chatting/entity/ChatRoomMember.java
@@ -30,4 +30,12 @@ public class ChatRoomMember {
     public ChatRoomMember(Long memberId, Long chatRoomId) {
         this.id = new ChatRoomMemberKey(chatRoomId, memberId);
     }
+
+    public void updateStatus() {
+        if (this.isExited == null) {
+            this.isExited = false;
+        } else {
+            this.isExited = !this.isExited;
+        }
+    }
 }

--- a/waggle-api/src/main/java/com/trip/api/chatting/mapper/ChattingMapper.java
+++ b/waggle-api/src/main/java/com/trip/api/chatting/mapper/ChattingMapper.java
@@ -10,11 +10,11 @@ import org.springframework.stereotype.Component;
 @Component
 public class ChattingMapper {
 
-    public ChatRoom convertCreateChatRoomReqDtoToEntity(CreateChatRoomRequest request) {
+    public ChatRoom createChatRoomRequestToEntity(CreateChatRoomRequest request) {
         return new ChatRoom(request.getChatRoomName(), request.getChatRoomMaker());
     }
 
-    public ChatMessage convertCreateChatMessageReqDtoToEntity(ConvertChatMessageParameter parameter) {
+    public ChatMessage createChatMessageRequestToEntity(ConvertChatMessageParameter parameter) {
         return ChatMessage.builder()
             .memberId(parameter.getMemberId())
             .chatRoomId(parameter.getChatRoomId())

--- a/waggle-api/src/main/java/com/trip/api/chatting/repository/ChatMessageRepository.java
+++ b/waggle-api/src/main/java/com/trip/api/chatting/repository/ChatMessageRepository.java
@@ -18,4 +18,6 @@ public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> 
                     "WHERE id = :chatMessageId AND is_deleted = false"
     )
     Optional<Long> findChatMessageById(Long chatMessageId);
+
+    void deleteAllByChatRoomId(Long chatRoomId);
 }

--- a/waggle-api/src/main/java/com/trip/api/chatting/repository/ChatRoomMemberRepository.java
+++ b/waggle-api/src/main/java/com/trip/api/chatting/repository/ChatRoomMemberRepository.java
@@ -18,4 +18,13 @@ public interface ChatRoomMemberRepository extends JpaRepository<ChatRoomMember, 
                     "WHERE chat_room_id = :chatRoomId AND member_id = :memberId"
     )
     void deleteChatRoomMember(Long chatRoomId, Long memberId);
+
+    @Modifying
+    @Query(
+            nativeQuery = true,
+            value = "UPDATE chat_room_member " +
+                    "SET is_exited = true " +
+                    "WHERE chat_room_id = :chatRoomId"
+    )
+    void deleteAllByChatRoomId(Long chatRoomId);
 }

--- a/waggle-api/src/main/java/com/trip/api/chatting/repository/ChatRoomMemberRepository.java
+++ b/waggle-api/src/main/java/com/trip/api/chatting/repository/ChatRoomMemberRepository.java
@@ -7,6 +7,8 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface ChatRoomMemberRepository extends JpaRepository<ChatRoomMember, Long> {
 
@@ -27,4 +29,12 @@ public interface ChatRoomMemberRepository extends JpaRepository<ChatRoomMember, 
                     "WHERE chat_room_id = :chatRoomId"
     )
     void deleteAllByChatRoomId(Long chatRoomId);
+
+    @Query(
+            nativeQuery = true,
+            value = "SELECT * " +
+                    "FROM chat_room_member " +
+                    "WHERE member_id = :memberId AND chat_room_id = :chatRoomId"
+    )
+    Optional<ChatRoomMember> findChatRoomMemberByMemberId(Long chatRoomId, Long memberId);
 }

--- a/waggle-api/src/main/java/com/trip/api/chatting/repository/ChatRoomRepository.java
+++ b/waggle-api/src/main/java/com/trip/api/chatting/repository/ChatRoomRepository.java
@@ -18,4 +18,12 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
                 "WHERE id = :chatRoomId AND is_deleted = false"
     )
     Optional<Long> findChatRoomById(Long chatRoomId);
+
+    @Query(
+        nativeQuery = true,
+        value = "SELECT creator " +
+                "FROM chat_room " +
+                "WHERE id = :chatRoomId AND is_deleted = false"
+    )
+    Optional<Long> findCreatorById(Long chatRoomId);
 }

--- a/waggle-api/src/main/java/com/trip/api/chatting/repository/ChattingQueryDslRepository.java
+++ b/waggle-api/src/main/java/com/trip/api/chatting/repository/ChattingQueryDslRepository.java
@@ -3,6 +3,7 @@ package com.trip.api.chatting.repository;
 import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
+import com.trip.api.chatting.dto.response.GetAllChatMember;
 import com.trip.api.chatting.dto.response.GetAllChatRoomResponse;
 import com.trip.api.chatting.dto.response.GetChatMessageResponse;
 import com.trip.api.chatting.dto.response.GetMyChatRoomResponse;
@@ -75,6 +76,23 @@ public class ChattingQueryDslRepository<T> {
             )
             .from(qChatRoom)
             .where(qChatRoom.isDeleted.eq(false))
+            .fetch();
+    }
+
+    // TODO: 유저 join 필요
+    public List<GetAllChatMember> findAllChatRoomMember(Long chatRoomId) {
+        return jpaQueryFactory
+            .select(
+                Projections.constructor(
+                    GetAllChatMember.class,
+                    qChatRoomMember.id.memberId.as("memberId")
+                )
+            )
+            .from(qChatRoomMember)
+            .where(
+                qChatRoomMember.id.chatRoomId.eq(chatRoomId),
+                qChatRoomMember.isExited.eq(false)
+            )
             .fetch();
     }
 }

--- a/waggle-api/src/main/java/com/trip/api/chatting/repository/ChattingQueryDslRepository.java
+++ b/waggle-api/src/main/java/com/trip/api/chatting/repository/ChattingQueryDslRepository.java
@@ -12,6 +12,7 @@ import com.trip.api.chatting.entity.QChatRoom;
 import com.trip.api.chatting.entity.QChatRoomMember;
 
 import lombok.RequiredArgsConstructor;
+
 import org.springframework.stereotype.Repository;
 
 import java.util.List;

--- a/waggle-api/src/main/java/com/trip/api/chatting/repository/ChattingQueryDslRepository.java
+++ b/waggle-api/src/main/java/com/trip/api/chatting/repository/ChattingQueryDslRepository.java
@@ -32,11 +32,12 @@ public class ChattingQueryDslRepository<T> {
                     qChatRoom.id.as("chatRoomId"),
                     qChatRoom.name.as("title")
                 )
-            )
+            ).distinct()
             .from(qChatRoom)
             .join(qChatRoomMember).on(qChatRoom.id.eq(qChatRoomMember.id.chatRoomId))
             .where(
-                qChatRoomMember.id.memberId.eq(memberId),
+                qChatRoomMember.id.memberId.eq(memberId)
+                    .or(qChatRoom.creator.eq(memberId)),
                 qChatRoomMember.isExited.eq(false),
                 qChatRoom.isDeleted.eq(false)
             )

--- a/waggle-api/src/main/java/com/trip/api/chatting/repository/ChattingQueryDslRepository.java
+++ b/waggle-api/src/main/java/com/trip/api/chatting/repository/ChattingQueryDslRepository.java
@@ -3,6 +3,7 @@ package com.trip.api.chatting.repository;
 import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
+import com.trip.api.chatting.dto.response.GetAllChatRoomResponse;
 import com.trip.api.chatting.dto.response.GetChatMessageResponse;
 import com.trip.api.chatting.dto.response.GetMyChatRoomResponse;
 import com.trip.api.chatting.entity.QChatMessage;
@@ -59,6 +60,21 @@ public class ChattingQueryDslRepository<T> {
             .from(qChatMessage)
             .join(qChatRoom).on(qChatRoom.id.eq(qChatMessage.chatRoomId))
             .where(qChatMessage.isDeleted.eq(false))
+            .fetch();
+    }
+
+    // TODO: 내가 속한 채팅방도 보여줄 것인지 확인
+    public List<GetAllChatRoomResponse> findAllChatRoom() {
+        return jpaQueryFactory
+            .select(
+                Projections.constructor(
+                    GetAllChatRoomResponse.class,
+                    qChatRoom.id.as("chatRoomId"),
+                    qChatRoom.name.as("title")
+                )
+            )
+            .from(qChatRoom)
+            .where(qChatRoom.isDeleted.eq(false))
             .fetch();
     }
 }

--- a/waggle-api/src/main/java/com/trip/api/chatting/repository/ChattingQueryDslRepository.java
+++ b/waggle-api/src/main/java/com/trip/api/chatting/repository/ChattingQueryDslRepository.java
@@ -3,7 +3,9 @@ package com.trip.api.chatting.repository;
 import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
+import com.trip.api.chatting.dto.response.GetChatMessageResponse;
 import com.trip.api.chatting.dto.response.GetMyChatRoomResponse;
+import com.trip.api.chatting.entity.QChatMessage;
 import com.trip.api.chatting.entity.QChatRoom;
 import com.trip.api.chatting.entity.QChatRoomMember;
 
@@ -14,11 +16,12 @@ import java.util.List;
 
 @RequiredArgsConstructor
 @Repository
-public class ChatRoomQueryDslRepository<T> {
+public class ChattingQueryDslRepository<T> {
 
     private final JPAQueryFactory jpaQueryFactory;
     private QChatRoom qChatRoom = QChatRoom.chatRoom;
     private QChatRoomMember qChatRoomMember = QChatRoomMember.chatRoomMember;
+    private QChatMessage qChatMessage = QChatMessage.chatMessage;
 
     // TODO: 페이지네이션 적용 여부 확인
     public List<GetMyChatRoomResponse> findAllMyChatRoom(Long memberId) {
@@ -37,6 +40,24 @@ public class ChatRoomQueryDslRepository<T> {
                 qChatRoomMember.isExited.eq(false),
                 qChatRoom.isDeleted.eq(false)
             )
+            .fetch();
+    }
+
+    // TODO: userNickname 조인 필요
+    public List<GetChatMessageResponse> findAllChatMessage(Long chatRoomId) {
+        return jpaQueryFactory
+            .select(
+                Projections.constructor(
+                    GetChatMessageResponse.class,
+                    qChatMessage.id.as("messageId"),
+                    qChatMessage.memberId.as("memberId"),
+                    qChatMessage.message.as("message"),
+                    qChatMessage.messageType.as("messageType")
+                )
+            )
+            .from(qChatMessage)
+            .join(qChatRoom).on(qChatRoom.id.eq(qChatMessage.chatRoomId))
+            .where(qChatMessage.isDeleted.eq(false))
             .fetch();
     }
 }

--- a/waggle-api/src/main/java/com/trip/api/chatting/service/ChattingService.java
+++ b/waggle-api/src/main/java/com/trip/api/chatting/service/ChattingService.java
@@ -48,6 +48,7 @@ public class ChattingService {
         chatRoomMemberRepository.deleteAllByChatRoomId(chatRoom.getId());
     }
 
+    @Transactional
     public void exitChatRoom(Long chatRoomId, Long memberId) {
         ChatRoom chatRoom = chatRoomRepository.findById(chatRoomId).orElseThrow();
         chatRoomMemberRepository.deleteChatRoomMember(chatRoom.getId(), memberId);

--- a/waggle-api/src/main/java/com/trip/api/chatting/service/ChattingService.java
+++ b/waggle-api/src/main/java/com/trip/api/chatting/service/ChattingService.java
@@ -4,9 +4,7 @@ import com.trip.api.chatting.dto.param.ConvertChatMessageParameter;
 import com.trip.api.chatting.dto.param.DeleteMessageParameter;
 import com.trip.api.chatting.dto.param.SendMessageParameter;
 import com.trip.api.chatting.dto.request.CreateChatRoomRequest;
-import com.trip.api.chatting.dto.response.GetAllChatRoomResponse;
-import com.trip.api.chatting.dto.response.GetChatMessageResponse;
-import com.trip.api.chatting.dto.response.GetMyChatRoomResponse;
+import com.trip.api.chatting.dto.response.*;
 import com.trip.api.chatting.entity.ChatMessage;
 import com.trip.api.chatting.entity.ChatRoom;
 import com.trip.api.chatting.entity.ChatRoomMember;
@@ -97,5 +95,13 @@ public class ChattingService {
     @Transactional(readOnly = true)
     public List<GetAllChatRoomResponse> getAllChatRoom() {
         return chattingQueryDslRepository.findAllChatRoom();
+    }
+
+    @Transactional(readOnly = true)
+    public GetAllChatRoomMemberResponse getAllChatRoomMember(Long chatRoomId) {
+        Long creatorId = chatRoomRepository.findCreatorById(chatRoomId).orElseThrow();
+        List<GetAllChatMember> members = chattingQueryDslRepository.findAllChatRoomMember(chatRoomId);
+
+        return new GetAllChatRoomMemberResponse(creatorId, members);
     }
 }

--- a/waggle-api/src/main/java/com/trip/api/chatting/service/ChattingService.java
+++ b/waggle-api/src/main/java/com/trip/api/chatting/service/ChattingService.java
@@ -40,9 +40,12 @@ public class ChattingService {
         return chatRoomId;
     }
 
+    @Transactional
     public void deleteChatRoom(Long chatRoomId) {
         ChatRoom chatRoom = chatRoomRepository.findById(chatRoomId).orElseThrow();
         chatRoomRepository.deleteById(chatRoom.getId());
+        chatMessageRepository.deleteAllByChatRoomId(chatRoom.getId());
+        chatRoomMemberRepository.deleteAllByChatRoomId(chatRoom.getId());
     }
 
     public void exitChatRoom(Long chatRoomId, Long memberId) {

--- a/waggle-api/src/main/java/com/trip/api/chatting/service/ChattingService.java
+++ b/waggle-api/src/main/java/com/trip/api/chatting/service/ChattingService.java
@@ -31,7 +31,7 @@ public class ChattingService {
 
     @Transactional
     public Long createChatRoom(CreateChatRoomRequest chatRoomRequest) {
-        ChatRoom chatRoom = chattingMapper.convertCreateChatRoomReqDtoToEntity(chatRoomRequest);
+        ChatRoom chatRoom = chattingMapper.createChatRoomRequestToEntity(chatRoomRequest);
         List<Long> joinUsers = chatRoomRequest.getJoinUsers();
         Long chatRoomId = chatRoomRepository.save(chatRoom).getId();
         chatRoomMemberDao.saveAllChatMembers(joinUsers, chatRoomId);
@@ -61,7 +61,7 @@ public class ChattingService {
 
     public Long sendMessage(SendMessageParameter parameter) {
         ChatRoom chatRoom = chatRoomRepository.findById(parameter.getChatRoomId()).orElseThrow();
-        ChatMessage chatMessage = chattingMapper.convertCreateChatMessageReqDtoToEntity(
+        ChatMessage chatMessage = chattingMapper.createChatMessageRequestToEntity(
             new ConvertChatMessageParameter(
                 parameter.getMemberId(),
                 chatRoom.getId(),

--- a/waggle-api/src/main/java/com/trip/api/chatting/service/ChattingService.java
+++ b/waggle-api/src/main/java/com/trip/api/chatting/service/ChattingService.java
@@ -4,6 +4,7 @@ import com.trip.api.chatting.dto.param.ConvertChatMessageParameter;
 import com.trip.api.chatting.dto.param.DeleteMessageParameter;
 import com.trip.api.chatting.dto.param.SendMessageParameter;
 import com.trip.api.chatting.dto.request.CreateChatRoomRequest;
+import com.trip.api.chatting.dto.response.GetChatMessageResponse;
 import com.trip.api.chatting.dto.response.GetMyChatRoomResponse;
 import com.trip.api.chatting.entity.ChatMessage;
 import com.trip.api.chatting.entity.ChatRoom;
@@ -24,7 +25,7 @@ public class ChattingService {
 
     private final ChatRoomRepository chatRoomRepository;
     private final ChatRoomMemberRepository chatRoomMemberRepository;
-    private final ChatRoomQueryDslRepository chatRoomQueryDslRepository;
+    private final ChattingQueryDslRepository chattingQueryDslRepository;
     private final ChatMessageRepository chatMessageRepository;
     private final ChatRoomMemberDao chatRoomMemberDao;
     private final ChattingMapper chattingMapper;
@@ -51,7 +52,7 @@ public class ChattingService {
 
     @Transactional(readOnly = true)
     public List<GetMyChatRoomResponse> getMyChatRooms(Long memberId) {
-        return chatRoomQueryDslRepository.findAllMyChatRoom(memberId);
+        return chattingQueryDslRepository.findAllMyChatRoom(memberId);
     }
 
     public void enterToChatRoom(Long memberId, Long chatRoomId) {
@@ -77,5 +78,11 @@ public class ChattingService {
         Long messageId = chatMessageRepository.findChatMessageById(parameter.getMessageId()).orElseThrow();
 
         chatMessageRepository.deleteById(messageId);
+    }
+
+    @Transactional(readOnly = true)
+    public List<GetChatMessageResponse> getChatMessages(Long chatRoomId) {
+        Long roomId = chatRoomRepository.findChatRoomById(chatRoomId).orElseThrow();
+        return chattingQueryDslRepository.findAllChatMessage(roomId);
     }
 }

--- a/waggle-api/src/main/java/com/trip/api/chatting/service/ChattingService.java
+++ b/waggle-api/src/main/java/com/trip/api/chatting/service/ChattingService.java
@@ -4,6 +4,7 @@ import com.trip.api.chatting.dto.param.ConvertChatMessageParameter;
 import com.trip.api.chatting.dto.param.DeleteMessageParameter;
 import com.trip.api.chatting.dto.param.SendMessageParameter;
 import com.trip.api.chatting.dto.request.CreateChatRoomRequest;
+import com.trip.api.chatting.dto.response.GetAllChatRoomResponse;
 import com.trip.api.chatting.dto.response.GetChatMessageResponse;
 import com.trip.api.chatting.dto.response.GetMyChatRoomResponse;
 import com.trip.api.chatting.entity.ChatMessage;
@@ -91,5 +92,10 @@ public class ChattingService {
     public List<GetChatMessageResponse> getChatMessages(Long chatRoomId) {
         Long roomId = chatRoomRepository.findChatRoomById(chatRoomId).orElseThrow();
         return chattingQueryDslRepository.findAllChatMessage(roomId);
+    }
+
+    @Transactional(readOnly = true)
+    public List<GetAllChatRoomResponse> getAllChatRoom() {
+        return chattingQueryDslRepository.findAllChatRoom();
     }
 }

--- a/waggle-api/src/main/java/com/trip/api/chatting/service/ChattingService.java
+++ b/waggle-api/src/main/java/com/trip/api/chatting/service/ChattingService.java
@@ -61,7 +61,10 @@ public class ChattingService {
 
     public void enterToChatRoom(Long memberId, Long chatRoomId) {
         Long roomId = chatRoomRepository.findChatRoomById(chatRoomId).orElseThrow();
-        chatRoomMemberRepository.save(new ChatRoomMember(memberId, roomId));
+        ChatRoomMember chatRoomMember = chatRoomMemberRepository.findChatRoomMemberByMemberId(roomId, memberId)
+            .orElseGet(() -> new ChatRoomMember(memberId, chatRoomId));
+        chatRoomMember.updateStatus();
+        chatRoomMemberRepository.save(chatRoomMember);
     }
 
     public Long sendMessage(SendMessageParameter parameter) {

--- a/waggle-api/src/main/java/com/trip/api/config/QueryDslConfig.java
+++ b/waggle-api/src/main/java/com/trip/api/config/QueryDslConfig.java
@@ -1,7 +1,9 @@
 package com.trip.api.config;
 
 import com.querydsl.jpa.impl.JPAQueryFactory;
+
 import lombok.RequiredArgsConstructor;
+
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 

--- a/waggle-api/src/main/java/com/trip/api/report/controller/ReportController.java
+++ b/waggle-api/src/main/java/com/trip/api/report/controller/ReportController.java
@@ -1,6 +1,6 @@
 package com.trip.api.report.controller;
 
-import com.trip.api.report.dto.request.CreateChatRoomReportRequest;
+import com.trip.api.report.dto.request.CreateReportRequest;
 import com.trip.api.report.service.ReportService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -18,10 +18,26 @@ public class ReportController {
 
     @PostMapping("/chat/{chatRoomId}")
     public ResponseEntity<Void> createChatRoomReport(
-        @Valid @RequestBody CreateChatRoomReportRequest chatRoomReportRequest,
+        @Valid @RequestBody CreateReportRequest reportRequest,
         @PathVariable Long chatRoomId
     ) {
-        Long reportId = reportService.createChatRoomReport(chatRoomReportRequest, 71L, chatRoomId);
+        Long reportId = reportService.createChatRoomReport(reportRequest, 71L, chatRoomId);
         return ResponseEntity.created(URI.create("/report/chat/" + reportId)).build();
+    }
+
+    @PostMapping("/chat/{chatRoomId}/message/{messageId}")
+    public ResponseEntity<Void> createChatMessageUserReport(
+        @PathVariable Long chatRoomId,
+        @PathVariable Long messageId,
+        @Valid @RequestBody CreateReportRequest reportRequest
+    ) {
+        Long reportId = reportService.createChatMessageUserReport(
+            reportRequest,
+            chatRoomId,
+            messageId,
+            71L
+        );
+
+        return ResponseEntity.created(URI.create("/report/chat/" + chatRoomId + "/message/" + messageId + "/" + reportId)).build();
     }
 }

--- a/waggle-api/src/main/java/com/trip/api/report/controller/ReportController.java
+++ b/waggle-api/src/main/java/com/trip/api/report/controller/ReportController.java
@@ -4,11 +4,14 @@ import com.trip.api.report.dto.param.CreateChatMessageReportParameter;
 import com.trip.api.report.dto.param.CreateChatRoomReportParameter;
 import com.trip.api.report.dto.request.CreateReportRequest;
 import com.trip.api.report.service.ReportService;
+
 import lombok.RequiredArgsConstructor;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
+
 import java.net.URI;
 
 @RestController

--- a/waggle-api/src/main/java/com/trip/api/report/controller/ReportController.java
+++ b/waggle-api/src/main/java/com/trip/api/report/controller/ReportController.java
@@ -1,5 +1,6 @@
 package com.trip.api.report.controller;
 
+import com.trip.api.report.dto.param.CreateChatRoomReportParameter;
 import com.trip.api.report.dto.request.CreateReportRequest;
 import com.trip.api.report.service.ReportService;
 import lombok.RequiredArgsConstructor;
@@ -21,7 +22,13 @@ public class ReportController {
         @Valid @RequestBody CreateReportRequest reportRequest,
         @PathVariable Long chatRoomId
     ) {
-        Long reportId = reportService.createChatRoomReport(reportRequest, 71L, chatRoomId);
+        Long reportId = reportService.createChatRoomReport(
+            new CreateChatRoomReportParameter(
+                reportRequest,
+                71L,
+                chatRoomId
+            )
+        );
         return ResponseEntity.created(URI.create("/report/chat/" + reportId)).build();
     }
 

--- a/waggle-api/src/main/java/com/trip/api/report/controller/ReportController.java
+++ b/waggle-api/src/main/java/com/trip/api/report/controller/ReportController.java
@@ -1,5 +1,6 @@
 package com.trip.api.report.controller;
 
+import com.trip.api.report.dto.param.CreateChatMessageReportParameter;
 import com.trip.api.report.dto.param.CreateChatRoomReportParameter;
 import com.trip.api.report.dto.request.CreateReportRequest;
 import com.trip.api.report.service.ReportService;
@@ -39,10 +40,12 @@ public class ReportController {
         @Valid @RequestBody CreateReportRequest reportRequest
     ) {
         Long reportId = reportService.createChatMessageUserReport(
-            reportRequest,
-            chatRoomId,
-            messageId,
-            71L
+            new CreateChatMessageReportParameter(
+                reportRequest,
+                chatRoomId,
+                messageId,
+                71L
+            )
         );
 
         return ResponseEntity.created(URI.create("/report/chat/" + chatRoomId + "/message/" + messageId + "/" + reportId)).build();

--- a/waggle-api/src/main/java/com/trip/api/report/dto/param/ConvertChatMessageReportParameter.java
+++ b/waggle-api/src/main/java/com/trip/api/report/dto/param/ConvertChatMessageReportParameter.java
@@ -1,0 +1,14 @@
+package com.trip.api.report.dto.param;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ConvertChatMessageReportParameter {
+
+    private Long messageId;
+    private Long reporterId;
+    private Long writerId;
+    private String reason;
+}

--- a/waggle-api/src/main/java/com/trip/api/report/dto/param/ConvertChatRoomReportParameter.java
+++ b/waggle-api/src/main/java/com/trip/api/report/dto/param/ConvertChatRoomReportParameter.java
@@ -8,7 +8,7 @@ import lombok.Getter;
 public class ConvertChatRoomReportParameter {
 
     private final Long chatRoomId;
-    private final Long writerId;
+    private final Long creatorId;
     private final Long reporterId;
     private final String reason;
 }

--- a/waggle-api/src/main/java/com/trip/api/report/dto/param/ConvertChatRoomReportParameter.java
+++ b/waggle-api/src/main/java/com/trip/api/report/dto/param/ConvertChatRoomReportParameter.java
@@ -1,0 +1,14 @@
+package com.trip.api.report.dto.param;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ConvertChatRoomReportParameter {
+
+    private final Long chatRoomId;
+    private final Long writerId;
+    private final Long reporterId;
+    private final String reason;
+}

--- a/waggle-api/src/main/java/com/trip/api/report/dto/param/CreateChatMessageReportParameter.java
+++ b/waggle-api/src/main/java/com/trip/api/report/dto/param/CreateChatMessageReportParameter.java
@@ -1,6 +1,7 @@
 package com.trip.api.report.dto.param;
 
 import com.trip.api.report.dto.request.CreateReportRequest;
+
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 

--- a/waggle-api/src/main/java/com/trip/api/report/dto/param/CreateChatMessageReportParameter.java
+++ b/waggle-api/src/main/java/com/trip/api/report/dto/param/CreateChatMessageReportParameter.java
@@ -1,0 +1,15 @@
+package com.trip.api.report.dto.param;
+
+import com.trip.api.report.dto.request.CreateReportRequest;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class CreateChatMessageReportParameter {
+
+    private CreateReportRequest reportRequest;
+    private Long chatRoomId;
+    private Long messageId;
+    private Long reporterId;
+}

--- a/waggle-api/src/main/java/com/trip/api/report/dto/param/CreateChatRoomReportParameter.java
+++ b/waggle-api/src/main/java/com/trip/api/report/dto/param/CreateChatRoomReportParameter.java
@@ -1,0 +1,14 @@
+package com.trip.api.report.dto.param;
+
+import com.trip.api.report.dto.request.CreateReportRequest;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class CreateChatRoomReportParameter {
+
+    private CreateReportRequest reportRequest;
+    private Long reporterId;
+    private Long chatRoomId;
+}

--- a/waggle-api/src/main/java/com/trip/api/report/dto/param/CreateChatRoomReportParameter.java
+++ b/waggle-api/src/main/java/com/trip/api/report/dto/param/CreateChatRoomReportParameter.java
@@ -1,6 +1,7 @@
 package com.trip.api.report.dto.param;
 
 import com.trip.api.report.dto.request.CreateReportRequest;
+
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 

--- a/waggle-api/src/main/java/com/trip/api/report/dto/request/CreateReportRequest.java
+++ b/waggle-api/src/main/java/com/trip/api/report/dto/request/CreateReportRequest.java
@@ -5,7 +5,7 @@ import lombok.Getter;
 import javax.validation.constraints.NotBlank;
 
 @Getter
-public class CreateChatRoomReportRequest {
+public class CreateReportRequest {
 
     @NotBlank
     private String reason;

--- a/waggle-api/src/main/java/com/trip/api/report/entity/ReportChatMessage.java
+++ b/waggle-api/src/main/java/com/trip/api/report/entity/ReportChatMessage.java
@@ -1,6 +1,8 @@
 package com.trip.api.report.entity;
 
 import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.annotations.DynamicInsert;
@@ -9,6 +11,7 @@ import javax.persistence.*;
 import javax.validation.constraints.NotNull;
 
 @Entity
+@Getter
 @DynamicInsert
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ReportChatMessage {
@@ -18,10 +21,13 @@ public class ReportChatMessage {
     private Long id;
 
     @Column(name = "chat_message_id", nullable = false)
-    private Long chatMessageId;
+    private Long messageId;
 
-    @Column(name = "member_id", nullable = false)
-    private Long memberId;
+    @Column(name = "writer_id", nullable = false)
+    private Long writerId;
+
+    @Column(name = "reporter_id", nullable = false)
+    private Long reporterId;
 
     @NotNull
     private String reason;
@@ -30,9 +36,11 @@ public class ReportChatMessage {
     @ColumnDefault("false")
     private Boolean isSolved;
 
-    public ReportChatMessage(Long chatMessageId, Long memberId, String reason) {
-        this.chatMessageId = chatMessageId;
-        this.memberId = memberId;
+    @Builder
+    public ReportChatMessage(Long messageId, Long writerId, Long reporterId, String reason) {
+        this.messageId = messageId;
+        this.writerId = writerId;
+        this.reporterId = reporterId;
         this.reason = reason;
     }
 }

--- a/waggle-api/src/main/java/com/trip/api/report/entity/ReportChatMessage.java
+++ b/waggle-api/src/main/java/com/trip/api/report/entity/ReportChatMessage.java
@@ -4,10 +4,12 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
 import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.annotations.DynamicInsert;
 
 import javax.persistence.*;
+
 import javax.validation.constraints.NotNull;
 
 @Entity

--- a/waggle-api/src/main/java/com/trip/api/report/entity/ReportChatRoom.java
+++ b/waggle-api/src/main/java/com/trip/api/report/entity/ReportChatRoom.java
@@ -24,8 +24,8 @@ public class ReportChatRoom {
     @Column(name = "chat_room_id", nullable = false)
     private Long chatRoomId;
 
-    @Column(name = "writer_id", nullable = false)
-    private Long writerId;
+    @Column(name = "creator_id", nullable = false)
+    private Long creatorId;
 
     @Column(name = "reporter_id", nullable = false)
     private Long reporterId;
@@ -38,9 +38,9 @@ public class ReportChatRoom {
     private Boolean isSolved;
 
     @Builder
-    public ReportChatRoom(Long chatRoomId, Long writerId, Long reporterId, String reason) {
+    public ReportChatRoom(Long chatRoomId, Long creatorId, Long reporterId, String reason) {
         this.chatRoomId = chatRoomId;
-        this.writerId = writerId;
+        this.creatorId = creatorId;
         this.reporterId = reporterId;
         this.reason = reason;
     }

--- a/waggle-api/src/main/java/com/trip/api/report/entity/ReportChatRoom.java
+++ b/waggle-api/src/main/java/com/trip/api/report/entity/ReportChatRoom.java
@@ -1,13 +1,12 @@
 package com.trip.api.report.entity;
 
-import lombok.AccessLevel;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
+
 import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.annotations.DynamicInsert;
 
 import javax.persistence.*;
+
 import javax.validation.constraints.NotNull;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/waggle-api/src/main/java/com/trip/api/report/entity/ReportChatRoom.java
+++ b/waggle-api/src/main/java/com/trip/api/report/entity/ReportChatRoom.java
@@ -1,6 +1,7 @@
 package com.trip.api.report.entity;
 
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.ColumnDefault;
@@ -36,6 +37,7 @@ public class ReportChatRoom {
     @ColumnDefault("false")
     private Boolean isSolved;
 
+    @Builder
     public ReportChatRoom(Long chatRoomId, Long writerId, Long reporterId, String reason) {
         this.chatRoomId = chatRoomId;
         this.writerId = writerId;

--- a/waggle-api/src/main/java/com/trip/api/report/mapper/ReportMapper.java
+++ b/waggle-api/src/main/java/com/trip/api/report/mapper/ReportMapper.java
@@ -12,7 +12,7 @@ public class ReportMapper {
     public ReportChatRoom createReportRequestToReportChatRoomEntity(ConvertChatRoomReportParameter parameter) {
         return ReportChatRoom.builder()
             .chatRoomId(parameter.getChatRoomId())
-            .writerId(parameter.getWriterId())
+            .creatorId(parameter.getCreatorId())
             .reporterId(parameter.getReporterId())
             .reason(parameter.getReason())
             .build();

--- a/waggle-api/src/main/java/com/trip/api/report/mapper/ReportMapper.java
+++ b/waggle-api/src/main/java/com/trip/api/report/mapper/ReportMapper.java
@@ -1,5 +1,6 @@
 package com.trip.api.report.mapper;
 
+import com.trip.api.report.dto.param.ConvertChatMessageReportParameter;
 import com.trip.api.report.dto.param.ConvertChatRoomReportParameter;
 import com.trip.api.report.entity.ReportChatMessage;
 import com.trip.api.report.entity.ReportChatRoom;
@@ -18,17 +19,12 @@ public class ReportMapper {
             .build();
     }
 
-    public ReportChatMessage createReportRequestToReportChatMessageEntity(
-        Long messageId,
-        Long reporterId,
-        Long writerId,
-        String reason
-    ) {
+    public ReportChatMessage createReportRequestToReportChatMessageEntity(ConvertChatMessageReportParameter parameter) {
         return ReportChatMessage.builder()
-            .messageId(messageId)
-            .reporterId(reporterId)
-            .writerId(writerId)
-            .reason(reason)
+            .messageId(parameter.getMessageId())
+            .reporterId(parameter.getReporterId())
+            .writerId(parameter.getWriterId())
+            .reason(parameter.getReason())
             .build();
     }
 }

--- a/waggle-api/src/main/java/com/trip/api/report/mapper/ReportMapper.java
+++ b/waggle-api/src/main/java/com/trip/api/report/mapper/ReportMapper.java
@@ -1,6 +1,7 @@
 package com.trip.api.report.mapper;
 
 import com.trip.api.report.dto.param.ConvertChatRoomReportParameter;
+import com.trip.api.report.entity.ReportChatMessage;
 import com.trip.api.report.entity.ReportChatRoom;
 
 import org.springframework.stereotype.Component;
@@ -8,12 +9,26 @@ import org.springframework.stereotype.Component;
 @Component
 public class ReportMapper {
 
-    public ReportChatRoom CreateChatRoomReportRequestToEntity(ConvertChatRoomReportParameter parameter) {
+    public ReportChatRoom createReportRequestToReportChatRoomEntity(ConvertChatRoomReportParameter parameter) {
         return ReportChatRoom.builder()
             .chatRoomId(parameter.getChatRoomId())
             .writerId(parameter.getWriterId())
             .reporterId(parameter.getReporterId())
             .reason(parameter.getReason())
+            .build();
+    }
+
+    public ReportChatMessage createReportRequestToReportChatMessageEntity(
+        Long messageId,
+        Long reporterId,
+        Long writerId,
+        String reason
+    ) {
+        return ReportChatMessage.builder()
+            .messageId(messageId)
+            .reporterId(reporterId)
+            .writerId(writerId)
+            .reason(reason)
             .build();
     }
 }

--- a/waggle-api/src/main/java/com/trip/api/report/mapper/ReportMapper.java
+++ b/waggle-api/src/main/java/com/trip/api/report/mapper/ReportMapper.java
@@ -1,0 +1,19 @@
+package com.trip.api.report.mapper;
+
+import com.trip.api.report.dto.param.ConvertChatRoomReportParameter;
+import com.trip.api.report.entity.ReportChatRoom;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class ReportMapper {
+
+    public ReportChatRoom CreateChatRoomReportRequestToEntity(ConvertChatRoomReportParameter parameter) {
+        return ReportChatRoom.builder()
+            .chatRoomId(parameter.getChatRoomId())
+            .writerId(parameter.getWriterId())
+            .reporterId(parameter.getReporterId())
+            .reason(parameter.getReason())
+            .build();
+    }
+}

--- a/waggle-api/src/main/java/com/trip/api/report/repository/ReportChatMessageRepository.java
+++ b/waggle-api/src/main/java/com/trip/api/report/repository/ReportChatMessageRepository.java
@@ -1,0 +1,8 @@
+package com.trip.api.report.repository;
+
+import com.trip.api.report.entity.ReportChatMessage;
+import com.trip.api.report.entity.ReportChatRoom;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReportChatMessageRepository extends JpaRepository<ReportChatMessage, Long> {
+}

--- a/waggle-api/src/main/java/com/trip/api/report/repository/ReportChatMessageRepository.java
+++ b/waggle-api/src/main/java/com/trip/api/report/repository/ReportChatMessageRepository.java
@@ -1,7 +1,7 @@
 package com.trip.api.report.repository;
 
 import com.trip.api.report.entity.ReportChatMessage;
-import com.trip.api.report.entity.ReportChatRoom;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ReportChatMessageRepository extends JpaRepository<ReportChatMessage, Long> {

--- a/waggle-api/src/main/java/com/trip/api/report/repository/ReportChatRoomRepository.java
+++ b/waggle-api/src/main/java/com/trip/api/report/repository/ReportChatRoomRepository.java
@@ -1,6 +1,7 @@
 package com.trip.api.report.repository;
 
 import com.trip.api.report.entity.ReportChatRoom;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 

--- a/waggle-api/src/main/java/com/trip/api/report/service/ReportService.java
+++ b/waggle-api/src/main/java/com/trip/api/report/service/ReportService.java
@@ -2,7 +2,9 @@ package com.trip.api.report.service;
 
 import com.trip.api.chatting.repository.ChatMessageRepository;
 import com.trip.api.chatting.repository.ChatRoomRepository;
+import com.trip.api.report.dto.param.ConvertChatMessageReportParameter;
 import com.trip.api.report.dto.param.ConvertChatRoomReportParameter;
+import com.trip.api.report.dto.param.CreateChatMessageReportParameter;
 import com.trip.api.report.dto.param.CreateChatRoomReportParameter;
 import com.trip.api.report.dto.request.CreateReportRequest;
 import com.trip.api.report.entity.ReportChatMessage;
@@ -43,18 +45,18 @@ public class ReportService {
         return reportChatRoomRepository.save(reportChatRoom).getId();
     }
 
-    public Long createChatMessageUserReport(
-        CreateReportRequest reportRequest,
-        Long chatRoomId,
-        Long messageId,
-        Long reporterId
-    ) {
+    public Long createChatMessageUserReport(CreateChatMessageReportParameter parameter) {
         Long writerId = 55L;
-        chatRoomRepository.findChatRoomById(chatRoomId).orElseThrow();
-        chatMessageRepository.findChatMessageById(messageId).orElseThrow();
+        chatRoomRepository.findChatRoomById(parameter.getChatRoomId()).orElseThrow();
+        chatMessageRepository.findChatMessageById(parameter.getMessageId()).orElseThrow();
 
         ReportChatMessage reportChatMessage = reportMapper.createReportRequestToReportChatMessageEntity(
-            messageId, reporterId, writerId, reportRequest.getReason()
+            new ConvertChatMessageReportParameter(
+                parameter.getMessageId(),
+                parameter.getReporterId(),
+                writerId,
+                parameter.getReportRequest().getReason()
+            )
         );
 
         return reportChatMessageRepository.save(reportChatMessage).getId();

--- a/waggle-api/src/main/java/com/trip/api/report/service/ReportService.java
+++ b/waggle-api/src/main/java/com/trip/api/report/service/ReportService.java
@@ -6,7 +6,6 @@ import com.trip.api.report.dto.param.ConvertChatMessageReportParameter;
 import com.trip.api.report.dto.param.ConvertChatRoomReportParameter;
 import com.trip.api.report.dto.param.CreateChatMessageReportParameter;
 import com.trip.api.report.dto.param.CreateChatRoomReportParameter;
-import com.trip.api.report.dto.request.CreateReportRequest;
 import com.trip.api.report.entity.ReportChatMessage;
 import com.trip.api.report.entity.ReportChatRoom;
 import com.trip.api.report.mapper.ReportMapper;

--- a/waggle-api/src/main/java/com/trip/api/report/service/ReportService.java
+++ b/waggle-api/src/main/java/com/trip/api/report/service/ReportService.java
@@ -12,11 +12,13 @@ import com.trip.api.report.repository.ReportChatMessageRepository;
 import com.trip.api.report.repository.ReportChatRoomRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 // TODO: writerId 탐색 기능 추가
 // TODO: admin에서 해당 신고 내용 조회 기능 추가
 @RequiredArgsConstructor
 @Service
+@Transactional
 public class ReportService {
 
     private final ReportChatRoomRepository reportChatRoomRepository;

--- a/waggle-api/src/main/java/com/trip/api/report/service/ReportService.java
+++ b/waggle-api/src/main/java/com/trip/api/report/service/ReportService.java
@@ -1,7 +1,9 @@
 package com.trip.api.report.service;
 
+import com.trip.api.report.dto.param.ConvertChatRoomReportParameter;
 import com.trip.api.report.dto.request.CreateChatRoomReportRequest;
 import com.trip.api.report.entity.ReportChatRoom;
+import com.trip.api.report.mapper.ReportMapper;
 import com.trip.api.report.repository.ReportChatRoomRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -11,6 +13,7 @@ import org.springframework.stereotype.Service;
 public class ReportService {
 
     private final ReportChatRoomRepository reportChatRoomRepository;
+    private final ReportMapper reportMapper;
 
     public Long createChatRoomReport(
         CreateChatRoomReportRequest chatRoomReportRequest,
@@ -18,12 +21,9 @@ public class ReportService {
         Long chatRoomId
     ) {
         // TODO: writerId 탐색 기능 추가
-        // TODO: Mapper 추가
-        ReportChatRoom reportChatRoom = new ReportChatRoom(
-            chatRoomId,
-            55L,
-            reporterId,
-            chatRoomReportRequest.getReason()
+        Long writerId = 10L;
+        ReportChatRoom reportChatRoom = reportMapper.CreateChatRoomReportRequestToEntity(
+            new ConvertChatRoomReportParameter(chatRoomId, writerId, reporterId, chatRoomReportRequest.getReason())
         );
 
         return reportChatRoomRepository.save(reportChatRoom).getId();

--- a/waggle-api/src/main/java/com/trip/api/report/service/ReportService.java
+++ b/waggle-api/src/main/java/com/trip/api/report/service/ReportService.java
@@ -1,5 +1,7 @@
 package com.trip.api.report.service;
 
+import com.trip.api.chatting.repository.ChatMessageRepository;
+import com.trip.api.chatting.repository.ChatRoomRepository;
 import com.trip.api.report.dto.param.ConvertChatRoomReportParameter;
 import com.trip.api.report.dto.request.CreateReportRequest;
 import com.trip.api.report.entity.ReportChatMessage;
@@ -18,6 +20,8 @@ public class ReportService {
 
     private final ReportChatRoomRepository reportChatRoomRepository;
     private final ReportChatMessageRepository reportChatMessageRepository;
+    private final ChatRoomRepository chatRoomRepository;
+    private final ChatMessageRepository chatMessageRepository;
     private final ReportMapper reportMapper;
 
     public Long createChatRoomReport(
@@ -25,9 +29,11 @@ public class ReportService {
         Long reporterId,
         Long chatRoomId
     ) {
-        Long writerId = 10L;
+        Long creatorId = 10L;
+        chatRoomRepository.findChatRoomById(chatRoomId).orElseThrow();
+
         ReportChatRoom reportChatRoom = reportMapper.createReportRequestToReportChatRoomEntity(
-            new ConvertChatRoomReportParameter(chatRoomId, writerId, reporterId, reportRequest.getReason())
+            new ConvertChatRoomReportParameter(chatRoomId, creatorId, reporterId, reportRequest.getReason())
         );
 
         return reportChatRoomRepository.save(reportChatRoom).getId();
@@ -40,6 +46,9 @@ public class ReportService {
         Long reporterId
     ) {
         Long writerId = 55L;
+        chatRoomRepository.findChatRoomById(chatRoomId).orElseThrow();
+        chatMessageRepository.findChatMessageById(messageId).orElseThrow();
+
         ReportChatMessage reportChatMessage = reportMapper.createReportRequestToReportChatMessageEntity(
             messageId, reporterId, writerId, reportRequest.getReason()
         );

--- a/waggle-api/src/main/java/com/trip/api/report/service/ReportService.java
+++ b/waggle-api/src/main/java/com/trip/api/report/service/ReportService.java
@@ -1,31 +1,49 @@
 package com.trip.api.report.service;
 
 import com.trip.api.report.dto.param.ConvertChatRoomReportParameter;
-import com.trip.api.report.dto.request.CreateChatRoomReportRequest;
+import com.trip.api.report.dto.request.CreateReportRequest;
+import com.trip.api.report.entity.ReportChatMessage;
 import com.trip.api.report.entity.ReportChatRoom;
 import com.trip.api.report.mapper.ReportMapper;
+import com.trip.api.report.repository.ReportChatMessageRepository;
 import com.trip.api.report.repository.ReportChatRoomRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+// TODO: writerId 탐색 기능 추가
+// TODO: admin에서 해당 신고 내용 조회 기능 추가
 @RequiredArgsConstructor
 @Service
 public class ReportService {
 
     private final ReportChatRoomRepository reportChatRoomRepository;
+    private final ReportChatMessageRepository reportChatMessageRepository;
     private final ReportMapper reportMapper;
 
     public Long createChatRoomReport(
-        CreateChatRoomReportRequest chatRoomReportRequest,
+        CreateReportRequest reportRequest,
         Long reporterId,
         Long chatRoomId
     ) {
-        // TODO: writerId 탐색 기능 추가
         Long writerId = 10L;
-        ReportChatRoom reportChatRoom = reportMapper.CreateChatRoomReportRequestToEntity(
-            new ConvertChatRoomReportParameter(chatRoomId, writerId, reporterId, chatRoomReportRequest.getReason())
+        ReportChatRoom reportChatRoom = reportMapper.createReportRequestToReportChatRoomEntity(
+            new ConvertChatRoomReportParameter(chatRoomId, writerId, reporterId, reportRequest.getReason())
         );
 
         return reportChatRoomRepository.save(reportChatRoom).getId();
+    }
+
+    public Long createChatMessageUserReport(
+        CreateReportRequest reportRequest,
+        Long chatRoomId,
+        Long messageId,
+        Long reporterId
+    ) {
+        Long writerId = 55L;
+        ReportChatMessage reportChatMessage = reportMapper.createReportRequestToReportChatMessageEntity(
+            messageId, reporterId, writerId, reportRequest.getReason()
+        );
+
+        return reportChatMessageRepository.save(reportChatMessage).getId();
     }
 }

--- a/waggle-api/src/main/java/com/trip/api/report/service/ReportService.java
+++ b/waggle-api/src/main/java/com/trip/api/report/service/ReportService.java
@@ -3,6 +3,7 @@ package com.trip.api.report.service;
 import com.trip.api.chatting.repository.ChatMessageRepository;
 import com.trip.api.chatting.repository.ChatRoomRepository;
 import com.trip.api.report.dto.param.ConvertChatRoomReportParameter;
+import com.trip.api.report.dto.param.CreateChatRoomReportParameter;
 import com.trip.api.report.dto.request.CreateReportRequest;
 import com.trip.api.report.entity.ReportChatMessage;
 import com.trip.api.report.entity.ReportChatRoom;
@@ -24,16 +25,17 @@ public class ReportService {
     private final ChatMessageRepository chatMessageRepository;
     private final ReportMapper reportMapper;
 
-    public Long createChatRoomReport(
-        CreateReportRequest reportRequest,
-        Long reporterId,
-        Long chatRoomId
-    ) {
+    public Long createChatRoomReport(CreateChatRoomReportParameter parameter) {
         Long creatorId = 10L;
-        chatRoomRepository.findChatRoomById(chatRoomId).orElseThrow();
+        chatRoomRepository.findChatRoomById(parameter.getChatRoomId()).orElseThrow();
 
         ReportChatRoom reportChatRoom = reportMapper.createReportRequestToReportChatRoomEntity(
-            new ConvertChatRoomReportParameter(chatRoomId, creatorId, reporterId, reportRequest.getReason())
+            new ConvertChatRoomReportParameter(
+                parameter.getChatRoomId(),
+                creatorId,
+                parameter.getReporterId(),
+                parameter.getReportRequest().getReason()
+            )
         );
 
         return reportChatRoomRepository.save(reportChatRoom).getId();


### PR DESCRIPTION
## Description ✍️
* 채팅 메세지 조회 기능 API
* 채팅 메세지 신고 기능 API
* 채팅방 삭제 로직 개선
* 채팅방 입장 및 퇴장 로직 개선
* 전체 채팅방 목록 조회 API
* 채팅방 멤버 목록 가져오기 API

## Screen Shot 📷
https://documenter.getpostman.com/view/19463591/2s9YJW4keU

## Test시 유의사항 ⚠️
* 내 채팅방 조회(/chat/my), 전체 채팅방 조회(/chat) 엔드포인트가 분리되었습니다.
* joinUsers의 경우 방장이 있기 때문에 검증하지 않아도 될 것 같아 validate를 제거했습니다.
